### PR TITLE
file mode needs to be a string

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,7 +3,7 @@ class chrony::config inherits chrony {
     ensure   => file,
     owner    => 0,
     group    => 0,
-    mode     => 0644,
+    mode     => '0644',
     content  => template($config_template),
     notify   => Service['chrony'],
   }


### PR DESCRIPTION
puppet throws warning if not set as string:

Warning: Non-string values for the file mode property are deprecated. It must be a string, either a symbolic mode like 'o+w,a+r' or an octal representation like '0644' or '755'.
