### PR TITLE
Fix indentation of => in config.pp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,10 +1,10 @@
 class chrony::config inherits chrony {
   file { $config:
-    ensure   => file,
-    owner    => 0,
-    group    => 0,
-    mode     => '0644',
-    content  => template($config_template),
-    notify   => Service['chrony'],
+    ensure  => file,
+    owner   => 0,
+    group   => 0,
+    mode    => '0644',
+    content => template($config_template),
+    notify  => Service['chrony'],
   }
 }


### PR DESCRIPTION
This should fix lint result warning "Indentation of => is not properly aligned - 6 occurrences." on Puppet forge quality score
