### PR TITLE
Fix for Puppet 4

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,8 @@
 class chrony::config inherits chrony {
   file { $config:
     ensure   => file,
-    owner    => 0,
-    group    => 0,
+    owner    => 'root',
+    group    => 'root',
     mode     => '0644',
     content  => template($config_template),
     notify   => Service['chrony'],


### PR DESCRIPTION
Error: Failed to apply catalog: Parameter mode failed on File[/etc/chrony/chrony.conf]: The file mode specification must be a string, not 'Fixnum' at /etc/puppetlabs/code/environments/production/modules/chrony/manifests/config.pp:2
